### PR TITLE
Add ability to call original getter/setter implementation from injected method

### DIFF
--- a/DeluxeInjection.podspec
+++ b/DeluxeInjection.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "DeluxeInjection"
-  s.version          = "0.2.0"
+  s.version          = "0.3.0"
   s.summary          = "Simplest Objective-C Dependency Injection (DI:syringe:) implementation ever"
 
   s.description      = <<-DESC

--- a/DeluxeInjection/Classes/DIDeluxeInjection.h
+++ b/DeluxeInjection/Classes/DIDeluxeInjection.h
@@ -23,6 +23,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Block types
 
+typedef id _Nullable (*DIOriginalGetter)(id target, SEL cmd);
+typedef void (*DIOriginalSetter)(id target, SEL cmd, id _Nullable value);
+
 /**
  *  Block to be injected instead of property getter
  *
@@ -31,26 +34,19 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return Injected value or \c [DeluxeInjection \c doNotInject] instance to not inject this property
  */
-typedef id _Nullable (^DIGetter)(id target, id _Nullable * _Nonnull ivar);
+typedef id _Nullable (^DIGetter)(id target, id _Nullable * _Nonnull ivar, DIOriginalGetter _Nullable originalGetter);
+typedef id _Nullable (^DIGetterWithoutOriginal)(id target, id _Nullable * _Nonnull ivar);
+typedef id _Nullable (^DIGetterWithoutIvar)(id target);
 
 /**
  *  Block to be injected instead of property setter
  *
  *  @param target Receiver of selector
  *  @param ivar Pointer to instance variable
- *
- *  @return Injected value or \c [DeluxeInjection \c doNotInject] instance to not inject this property
  */
-typedef void (^DISetter)(id target, id _Nullable * _Nonnull ivar, id value);
-
-/**
- *  Block to be injected instead of property getter
- *
- *  @param target Receiver of selector
- *
- *  @return Injected value or \c nil
- */
-typedef id _Nullable (^DIGetterWithoutIvar)(id target);
+typedef void (^DISetter)(id target, id _Nullable * _Nonnull ivar, id value, DIOriginalSetter _Nullable originalSetter);
+typedef void (^DISetterWithoutOriginal)(id target, id _Nullable * _Nonnull ivar, id value);
+typedef void (^DISetterWithoutIvar)(id target, id value);
 
 /**
  *  Block to be injected for property
@@ -119,8 +115,10 @@ typedef BOOL (^DIPropertyFilter)(Class targetClass, NSString *propertyName, Clas
 /**
  *  Helper methods to create DIGetter and DISetter with Xcode autocomplete :)
  */
-DIGetter DIGetterMake(DIGetter getter);
-DISetter DISetterMake(DISetter setter);
+DIGetter DIGetterMake(DIGetterWithoutOriginal getter);
+DISetter DISetterMake(DISetterWithoutOriginal setter);
+DIGetter DIGetterWithOriginalMake(DIGetter getter);
+DISetter DISetterWithOriginalMake(DISetter setter);
 
 /**
  *  Transforms getter block without \c ivar argument to block with \c ivar argument this way:
@@ -155,9 +153,7 @@ id DIGetterSuperCall(id target, Class klass, SEL getter);
  *
  *  @param target Target to call
  *  @param klass  Class of current setter implementation
- *  @param getter Selector to call
- *
- *  @return Return value be supers setter
+ *  @param setter Selector to call
  */
 void DISetterSuperCall(id target, Class klass, SEL setter, id value);
 
@@ -198,7 +194,7 @@ void DISetterSuperCall(id target, Class klass, SEL setter, id value);
  *  @param setter Class property setter to inject
  *  @param setterBlock Block to be injected into setter
  */
-+ (void)inject:(Class)klass setter:(SEL)getter setterBlock:(DISetter)setterBlock;
++ (void)inject:(Class)klass setter:(SEL)setter setterBlock:(DISetter)setterBlock;
 
 /**
  *  Reject concrete property injection

--- a/Example/DeluxeInjection.xcodeproj/project.pbxproj
+++ b/Example/DeluxeInjection.xcodeproj/project.pbxproj
@@ -431,6 +431,7 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
@@ -471,6 +472,7 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
@@ -532,11 +534,6 @@
 			baseConfigurationReference = DE9A9F81BBBE43EA4D1527E8 /* Pods-DeluxeInjection_Tests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Tests/Tests-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -556,11 +553,6 @@
 			baseConfigurationReference = 7E0D553882C7D23CCDB521D0 /* Pods-DeluxeInjection_Tests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Tests/Tests-Prefix.pch";
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";


### PR DESCRIPTION
Made this code to work in pet project:

``` objective-c
@interface SettingsViewController ()

@property (strong, nonatomic) NSDate<DIDefaults> *fromTime;
@property (strong, nonatomic) NSDate<DIDefaults> *toTime;
@property (strong, nonatomic) NSDate<DIDefaults> *everyTime;

@end

@implementation SettingsViewController

- (void)setFromTime:(NSDate *)fromTime {
    self.fromLabel.text = [self.hhmmFormatter stringFromDate:fromTime];
}

- (void)setToTime:(NSDate *)toTime {
    self.toLabel.text = [self.hhmmFormatter stringFromDate:toTime];
}

- (void)setEveryTime:(NSDate *)everyTime {
    self.everyHrLabel.text = [self.hhFormatter stringFromDate:everyTime];
    self.everyMinLabel.text = [self.mmFormatter stringFromDate:everyTime];
}

@end
```
